### PR TITLE
Include platform name in artifactId to separate builds for different platforms

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -46,7 +46,7 @@ val javadocJar = tasks.register<Jar>("javadocJar") {
 publishing {
     publications {
         withType<MavenPublication> {
-            artifactId = "osm-legal-default-speeds"
+            artifactId = "osm-legal-default-speeds-$name"
             artifact(javadocJar)
             pom {
                 name.set("osm-legal-default-speeds")


### PR DESCRIPTION
Fixes #2. Don't know much about this, but by including the name in artifactId we get different artifacts for the different platforms. In my  local m2 folder it looks like this:

```
├── osm-legal-default-speeds-js
│   ├── 1.1
│   │   ├── osm-legal-default-speeds-js-1.1.jar
│   │   ├── osm-legal-default-speeds-js-1.1-javadoc.jar
│   │   ├── osm-legal-default-speeds-js-1.1.klib
│   │   ├── osm-legal-default-speeds-js-1.1.module
│   │   ├── osm-legal-default-speeds-js-1.1.pom
│   │   └── osm-legal-default-speeds-js-1.1-sources.jar
│   └── maven-metadata-local.xml
├── osm-legal-default-speeds-jvm
│   ├── 1.1
│   │   ├── osm-legal-default-speeds-jvm-1.1.jar
│   │   ├── osm-legal-default-speeds-jvm-1.1-javadoc.jar
│   │   ├── osm-legal-default-speeds-jvm-1.1.module
│   │   ├── osm-legal-default-speeds-jvm-1.1.pom
│   │   └── osm-legal-default-speeds-jvm-1.1-sources.jar
│   └── maven-metadata-local.xml
├── osm-legal-default-speeds-kotlinMultiplatform
│   ├── 1.1
│   │   ├── osm-legal-default-speeds-kotlinMultiplatform-1.1.jar
│   │   ├── osm-legal-default-speeds-kotlinMultiplatform-1.1-javadoc.jar
│   │   ├── osm-legal-default-speeds-kotlinMultiplatform-1.1-kotlin-tooling-metadata.json
│   │   ├── osm-legal-default-speeds-kotlinMultiplatform-1.1.module
│   │   ├── osm-legal-default-speeds-kotlinMultiplatform-1.1.pom
│   │   └── osm-legal-default-speeds-kotlinMultiplatform-1.1-sources.jar
│   └── maven-metadata-local.xml
└── osm-legal-default-speeds-native
    ├── 1.1
    │   ├── osm-legal-default-speeds-native-1.1-javadoc.jar
    │   ├── osm-legal-default-speeds-native-1.1.klib
    │   ├── osm-legal-default-speeds-native-1.1.module
    │   ├── osm-legal-default-speeds-native-1.1.pom
    │   └── osm-legal-default-speeds-native-1.1-sources.jar
    └── maven-metadata-local.xml
```