### PR TITLE
option to avoid expensive limitSpeedsTo

### DIFF
--- a/library/src/commonMain/kotlin/de/westnordost/osm_legal_default_speeds/LegalDefaultSpeeds.kt
+++ b/library/src/commonMain/kotlin/de/westnordost/osm_legal_default_speeds/LegalDefaultSpeeds.kt
@@ -21,6 +21,7 @@ class LegalDefaultSpeeds(
     roadTypesByName: Map<String, RoadTypeFilter>,
     private val speedLimitsByCountryCode: Map<String, List<RoadType>>
 ) {
+    var limitOtherSpeeds: Boolean = true
     private val roadTypeFilters: Map<String, RoadTypeTagFilterExpressions> = roadTypesByName.mapValues { (roadName, roadTypeFilter) ->
         /* let's parse the filters defined in strings right in the constructor, so it doesn't
            need to be done again and again (and if there is a syntax error, it becomes apparent
@@ -207,15 +208,16 @@ class LegalDefaultSpeeds(
         }
         return null
     }
-}
 
-private fun createResultTags(tags: Map<String, String>, roadTypeTags: Map<String, String>): Map<String, String> {
-    val result = roadTypeTags.toMutableMap()
-    result.putAll(tags.filter { !it.isImplicitMaxSpeed })
-    val maxspeed = result["maxspeed"]?.withOptionalUnitToDoubleOrNull()
-    result.limitSpeedsTo("maxspeed", maxspeed)
-    tags.entries.forEach { if (!it.isImplicitMaxSpeed) result.remove(it.key) }
-    return result
+    private fun createResultTags(tags: Map<String, String>, roadTypeTags: Map<String, String>): Map<String, String> {
+        if (!limitOtherSpeeds) return roadTypeTags
+        val result = roadTypeTags.toMutableMap()
+        result.putAll(tags.filter { !it.isImplicitMaxSpeed })
+        val maxspeed = result["maxspeed"]?.withOptionalUnitToDoubleOrNull()
+        result.limitSpeedsTo("maxspeed", maxspeed)
+        tags.entries.forEach { if (!it.isImplicitMaxSpeed) result.remove(it.key) }
+        return result
+    }
 }
 
 // stuff like maxspeed=RO:urban from the input tags should not overwrite explicit speed limits from output tags


### PR DESCRIPTION
Related to #7.

I think our use case allows us to skip the currently expensive method limitSpeedsTo (in terms of speed or memory usage).

When we set this option to false the method is skipped and we have to limit all other speed tags except `maxspeed` to the `maxspeed` value.