### PR TITLE
Add wheel_restriction

### DIFF
--- a/parser/parsers/osm_restrictions.py
+++ b/parser/parsers/osm_restrictions.py
@@ -53,6 +53,8 @@ def osm_speed_visitor(t):
         return f"axles>={t.children[0]}"
     elif t.data == "trailers_restriction":
         return f"trailers>={t.children[0]}"
+    elif t.data == "wheel_restriction":
+        return f"wheels>={t.children[0]}"
     elif t.data in {"restriction_conditional", "time_time", "time_event"}:
         return t.children[0]
     elif t.data == "date_interval":

--- a/parser/parsers/speed_grammar.ebnf
+++ b/parser/parsers/speed_grammar.ebnf
@@ -26,9 +26,10 @@ _restrictions: restriction
 restriction: weight                   -> weight_restriction
            | RESTRICTION_CONDITIONAL  -> restriction_conditional
            | NUMBER+ LENGTH_UNIT      -> length_restriction
-           | NUMBER+ "seats"          -> seat_restriction
-           | NUMBER+ "axles"          -> axle_restriction
-           | NUMBER+ "trailers"       -> trailers_restriction
+           | NUMBER+ " seats"         -> seat_restriction
+           | NUMBER+ " axles"         -> axle_restriction
+           | NUMBER+ " trailers"      -> trailers_restriction
+           | NUMBER+ " wheels"        -> wheel_restriction
            | date_interval            -> date_interval
 
 weight: WEIGHT WEIGHT_UNIT                   -> weight_rating

--- a/parser/parsers/speed_grammar.ebnf
+++ b/parser/parsers/speed_grammar.ebnf
@@ -26,10 +26,10 @@ _restrictions: restriction
 restriction: weight                   -> weight_restriction
            | RESTRICTION_CONDITIONAL  -> restriction_conditional
            | NUMBER+ LENGTH_UNIT      -> length_restriction
-           | NUMBER+ " seats"         -> seat_restriction
-           | NUMBER+ " axles"         -> axle_restriction
-           | NUMBER+ " trailers"      -> trailers_restriction
-           | NUMBER+ " wheels"        -> wheel_restriction
+           | NUMBER+ "seats"          -> seat_restriction
+           | NUMBER+ "axles"          -> axle_restriction
+           | NUMBER+ "trailers"       -> trailers_restriction
+           | NUMBER+ "wheels"         -> wheel_restriction
            | date_interval            -> date_interval
 
 weight: WEIGHT WEIGHT_UNIT                   -> weight_rating


### PR DESCRIPTION
Wiki parsing failed with the following error:

```
Traceback (most recent call last):
  File "parser\parsers\parse_utils.py", line 126, in parse_speed_table
    parsed_speeds = speed_parse_func(speeds)
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "parser\parsers\osm_restrictions.py", line 92, in parse_speeds
    parse_tree = parser.parse(s)
                 ^^^^^^^^^^^^^^^
  File "Python\Python312\Lib\site-packages\lark\lark.py", line 581, in parse
    return self.parser.parse(text, start=start, on_error=on_error)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Python\Python312\Lib\site-packages\lark\parser_frontends.py", line 106, in parse
    return self.parser.parse(stream, chosen_start, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Python\Python312\Lib\site-packages\lark\parsers\earley.py", line 297, in parse
    to_scan = self._parse(lexer, columns, to_scan, start_symbol)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Python\Python312\Lib\site-packages\lark\parsers\xearley.py", line 144, in _parse
    to_scan = scan(i, to_scan)
              ^^^^^^^^^^^^^^^^
  File "Python\Python312\Lib\site-packages\lark\parsers\xearley.py", line 118, in scan
    raise UnexpectedCharacters(stream, i, text_line, text_column, {item.expect.name for item in to_scan},
lark.exceptions.UnexpectedCharacters: No terminal matches 'w' in the current parser context, at line 2 col 7

95 (6 wheels)
      ^
Expected one of:
        * WEIGHT_UNIT
        * LENGTH_UNIT
        * TRAILERS
        * SEATS
        * NUMBER
        * AXLES
```

This PR adds support for the new wheels restriction