### PR TITLE
Fix some wiki-parser issues

### DIFF
--- a/parser/main.py
+++ b/parser/main.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     result["meta"] = {
         "source": WIKI_URL + WIKI_PAGE,
         "revisionId": str(parsed["revid"]),
-        "timestamp": datetime.datetime.utcnow().replace(microsecond=0).isoformat(),
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat(),
         "license": "Creative Commons Attribution-ShareAlike 2.0 license",
         "licenseUrl": "https://wiki.openstreetmap.org/wiki/Wiki_content_license",
     }

--- a/parser/parsers/osm_restrictions.py
+++ b/parser/parsers/osm_restrictions.py
@@ -59,12 +59,20 @@ def osm_speed_visitor(t):
         return t.children[0]
     elif t.data == "date_interval":
         return " ".join([osm_speed_visitor(child) for child in filter(None, t.children)])
+    elif t.data == "date_intervals":
+        return "; ".join([osm_speed_visitor(child) for child in filter(None, t.children)])
+    elif t.data == "off":
+        return f"off"
     elif t.data == "time_span":
         return f"{osm_speed_visitor(t.children[0])}-{osm_speed_visitor(t.children[1])}"
     elif t.data == "event_with_offset":
         return f"({osm_speed_visitor(t.children[0])})"
     elif t.data in {"neg_interval", "time_span", "weekday_span", "month_span"}:
         return f"{t.children[0]}-{t.children[1]}"
+    elif t.data == "weekday":
+        return f"{t.children[0]}"
+    elif t.data == "weekday_list":
+        return ",".join([osm_speed_visitor(child) for child in filter(None, t.children)])
     elif t.data == "pos_interval":
         return f"{t.children[0]}+{t.children[1]}"
 

--- a/parser/parsers/speed_grammar.ebnf
+++ b/parser/parsers/speed_grammar.ebnf
@@ -39,11 +39,13 @@ weight: WEIGHT WEIGHT_UNIT                   -> weight_rating
 date_intervals: date_interval
              | date_interval ";" date_intervals
 
-date_interval: [month_span] [weekday_span] time_span
-             | [month_span] weekday_span
-             | month_span
+date_interval: [month_span] [weekday_span] time_span [off]
+             | [month_span] weekday_span [off]
+             | month_span [off]
 
 month_span: MONTH "-" MONTH
+
+off: OFF -> off
 
 weekday_span: WEEKDAY "-" WEEKDAY
             | weekday_list -> weekday_list
@@ -52,7 +54,6 @@ weekday_span: WEEKDAY "-" WEEKDAY
 weekday_list: weekday_span "," weekday_span
 
 time_span: time "-" time
-            | "off" -> off
 
 time: TIME                       -> time_time
     | EVENT                      -> time_event
@@ -77,6 +78,7 @@ TIME: /[0-9][0-9]:[0-9][0-9]/
 EVENT: "sunset" | "sunrise" | "dusk" | "dawn"
 WEEKDAY: "Mo" | "Tu" | "We" | "Th" | "Fr" | "Sa" | "Su" | "PH" | "SH"
 MONTH: "Jan" | "Feb" | "Mar" | "Apr" | "May" | "Jun" | "Jul" | "Aug" | "Sep" | "Oct" | "Nov" | "Dec"
+OFF: "off"
 
 %import common.INT -> NUMBER
 %import common.WS

--- a/parser/parsers/speed_grammar.ebnf
+++ b/parser/parsers/speed_grammar.ebnf
@@ -30,11 +30,14 @@ restriction: weight                   -> weight_restriction
            | NUMBER+ "axles"          -> axle_restriction
            | NUMBER+ "trailers"       -> trailers_restriction
            | NUMBER+ "wheels"         -> wheel_restriction
-           | date_interval            -> date_interval
+           | date_intervals           -> date_intervals
 
 weight: WEIGHT WEIGHT_UNIT                   -> weight_rating
       | WEIGHT_QUALIFIER WEIGHT WEIGHT_UNIT  -> qualified_weight_pre
       | WEIGHT WEIGHT_UNIT WEIGHT_QUALIFIER  -> qualified_weight_post
+
+date_intervals: date_interval
+             | date_interval ";" date_intervals
 
 date_interval: [month_span] [weekday_span] time_span
              | [month_span] weekday_span
@@ -43,8 +46,13 @@ date_interval: [month_span] [weekday_span] time_span
 month_span: MONTH "-" MONTH
 
 weekday_span: WEEKDAY "-" WEEKDAY
+            | weekday_list -> weekday_list
+            | WEEKDAY -> weekday
+
+weekday_list: weekday_span "," weekday_span
 
 time_span: time "-" time
+            | "off" -> off
 
 time: TIME                       -> time_time
     | EVENT                      -> time_event
@@ -67,8 +75,8 @@ LENGTH_UNIT: "m" | "ft"
 
 TIME: /[0-9][0-9]:[0-9][0-9]/
 EVENT: "sunset" | "sunrise" | "dusk" | "dawn"
-WEEKDAY: "Mo" | "Tu" | "We" | "Th" | "Fr" | "Sa" | "So"
-MONTH: "Jan" | "Feb" | "Mar" | "Apr" | "Jun" | "Jul" | "Aug" | "Sep" | "Oct" | "Nov" | "Dec"
+WEEKDAY: "Mo" | "Tu" | "We" | "Th" | "Fr" | "Sa" | "Su" | "PH" | "SH"
+MONTH: "Jan" | "Feb" | "Mar" | "Apr" | "May" | "Jun" | "Jul" | "Aug" | "Sep" | "Oct" | "Nov" | "Dec"
 
 %import common.INT -> NUMBER
 %import common.WS

--- a/parser/test_speed_parser.py
+++ b/parser/test_speed_parser.py
@@ -81,6 +81,8 @@ from parsers.parse_utils import validate_road_types_in_speed_table
         ("40 (Sep-Jun Mo-Fr 08:00-16:00)", {"maxspeed:conditional": "40 @ (Sep-Jun Mo-Fr 08:00-16:00)"}),
         ("40 (08:00-16:00)", {"maxspeed:conditional": "40 @ (08:00-16:00)"}),
         ("40 (Mo-Fr)", {"maxspeed:conditional": "40 @ (Mo-Fr)"}),
+        ("30 (Mo-Fr 08:00-17:00; PH,SH off)", {"maxspeed:conditional": "30 @ (Mo-Fr 08:00-17:00; PH,SH off)"}),
+        ("30 (Oct-May Sa,Su)", {"maxspeed:conditional": "30 @ (Oct-May Sa,Su)"}),
         
         # Advisory speed
         ("advisory: 130", {"maxspeed:advisory": "130"}),

--- a/parser/test_speed_parser.py
+++ b/parser/test_speed_parser.py
@@ -82,7 +82,7 @@ from parsers.parse_utils import validate_road_types_in_speed_table
         ("40 (08:00-16:00)", {"maxspeed:conditional": "40 @ (08:00-16:00)"}),
         ("40 (Mo-Fr)", {"maxspeed:conditional": "40 @ (Mo-Fr)"}),
         ("30 (Mo-Fr 08:00-17:00; PH,SH off)", {"maxspeed:conditional": "30 @ (Mo-Fr 08:00-17:00; PH,SH off)"}),
-        ("30 (Oct-May Sa,Su)", {"maxspeed:conditional": "30 @ (Oct-May Sa,Su)"}),
+        ("30 (Oct-May Sa,Su off)", {"maxspeed:conditional": "30 @ (Oct-May Sa,Su off)"}),
         
         # Advisory speed
         ("advisory: 130", {"maxspeed:advisory": "130"}),


### PR DESCRIPTION
This fixes the following wiki-parser issues

1. `Su` instead of `So`
2. Missing `May` in months
3. Support comma-separated lists of weekdays
4. Support weekdays without ranges (just `Su`, not only `Sa-Su`)
5. Support `PH` and `SH` as "weekdays"
6. Support semicolon-separated date intervals
7. Support `off` as a time range

I added some tests for these fixes as well, and also moved the `main.py` to newer UTC0time handling.